### PR TITLE
[docker-compose.yml] Default LIBRARIES_IO_TOKEN to special value

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -195,6 +195,11 @@ services:
       BAYESIAN_DATA_IMPORTER_SERVICE_HOST: "data-model-importer"
       BAYESIAN_DATA_IMPORTER_SERVICE_PORT: "9192"
       SCANCODE_PROCESSES: "4"
+      # 'no-token' value forces the API call to not use ANY token.
+      # It works, but if abused, they can ban your IP.
+      # So if you need to analyse big number of packages locally,
+      # set this to your API Key (get it from https://libraries.io/account)
+      LIBRARIES_IO_TOKEN: "no-token"
     tty: true  # yes, really -ti -d, binwalk chokes when there's no tty kept open
   worker-ingestion:
     <<: *worker


### PR DESCRIPTION
See also
https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/511

We use this special `"no-token"` value only here in docker-compose.yml and in [worker unit tests](https://github.com/fabric8-analytics/fabric8-analytics-worker/commit/765006ac57049b4507abd9b18169f72a75be6456).

For [deployment to openshift it needs to be set](https://github.com/fabric8-analytics/fabric8-analytics-common/commit/0fbd59337d8d00b6551a550d18b00fc89949fc07) to real API token.